### PR TITLE
feat: split ExperienceCard into View and Edit modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@vitejs/plugin-react": "^6.0.0",
         "concurrently": "^9.2.1",
         "electron": "^41.0.3",
+        "esbuild": "^0.28.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -2241,6 +2242,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -9237,6 +9680,48 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "concurrently": "^9.2.1",
     "electron": "^41.0.3",
+    "esbuild": "^0.28.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/src/components/mainPannels/experiences/Experience.tsx
+++ b/src/components/mainPannels/experiences/Experience.tsx
@@ -1,6 +1,6 @@
 import { useProfileStore } from "@/store/profile";
 import { useState } from "react";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import type { Experience } from "@shared/Experience.interface";
 import ExperienceCard from "./ExperienceCard";
 
@@ -14,24 +14,65 @@ export default function ExperienceComponent() {
     }
 
     const handleNewSave = (newExperience: Experience) => {
-        const id = new Date().getTime().toString(); // id here is fine
-        const newData = [...experience, {...newExperience, id: id}];
+        const id = new Date().getTime().toString();
+        const newData = [...experience, { ...newExperience, id }];
         updateSection("experience", newData);
         setAddNew(false);
     }
 
+    const handleOnDelete = (id: string) => {
+        const newExperienceList = experience.filter((exp) => exp.id !== id);
+        updateSection("experience", newExperienceList);
+    }
+
     return (
-        <motion.div className="w-full h-full flex flex-col gap-4" initial={{ opacity: 0, x: -200 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0 }} transition={{ duration: 0.5 }}>
+        <motion.div 
+            className="w-full h-full flex flex-col gap-4" 
+            initial={{ opacity: 0, x: -200 }} 
+            animate={{ opacity: 1, x: 0 }} 
+            exit={{ opacity: 0 }} 
+            transition={{ duration: 0.5 }}
+        >
             { experience.length === 0 && <h2 className="text-2xl font-bold">No experience entries yet.</h2> }
-            {experience.map((exp) => (
-                <ExperienceCard key={exp.id} experience={exp} onSave={handleOnSave} />
-            ))}
-            {addNew ? (
-                <ExperienceCard experience={{ id: "", company: "", jobTitle: "", location: "", startDate: new Date() }} onSave={handleNewSave} />
-            ) : (
+            
+            <AnimatePresence mode="popLayout">
+                {experience.map((exp) => (
+                    <motion.div
+                        key={exp.id}
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, scale: 0.95 }}
+                        transition={{ duration: 0.3 }}
+                    >
+                        <ExperienceCard 
+                            experience={exp} 
+                            onSave={handleOnSave} 
+                            onDelete={handleOnDelete} 
+                        />
+                    </motion.div>
+                ))}
+                {addNew && (
+                    <motion.div
+                        key="new-experience"
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, scale: 0.95 }}
+                        transition={{ duration: 0.3 }}
+                    >
+                        <ExperienceCard 
+                            experience={{ id: "", company: "", jobTitle: "", location: "", startDate: new Date() }} 
+                            onSave={handleNewSave} 
+                            onCancel={() => setAddNew(false)}
+                            defaultEdit={true}
+                        />
+                    </motion.div>
+                )}
+            </AnimatePresence>
+
+            {!addNew && (
                 <button
                     onClick={() => setAddNew(true)}
-                    className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+                    className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition-colors duration-200 mt-2"
                 >
                     Add Experience
                 </button>

--- a/src/components/mainPannels/experiences/ExperienceCard.tsx
+++ b/src/components/mainPannels/experiences/ExperienceCard.tsx
@@ -6,12 +6,26 @@ import { Input } from "@/components/ui/input";
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupTextarea } from "@/components/ui/input-group";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import type { Experience } from "@shared/Experience.interface";
-import { Building, ChevronDown, LocationEdit } from "lucide-react";
+import { Building, ChevronDown, MapPin, Calendar as LucideCalendar, Edit2, Trash2, X, Save, ArrowLeft } from "lucide-react";
 import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 
-export default function ExperienceCard({experience, onSave}: { experience: Experience; onSave: (updatedExperience: Experience) => void }) {
+export default function ExperienceCard({
+    experience,
+    onSave,
+    onCancel,
+    onDelete,
+    defaultEdit = false
+}: {
+    experience: Experience;
+    onSave: (updatedExperience: Experience) => void;
+    onCancel?: () => void;
+    onDelete?: (id: string) => void;
+    defaultEdit?: boolean;
+}) {
     const [formData, setFormData] = useState<Experience>(experience);
     const [isCurrent, setIsCurrent] = useState(experience.endDate === "Present");
+    const [isEditing, setIsEditing] = useState(defaultEdit);
 
     useEffect(() => {
         const updateFormData = () => {
@@ -23,84 +37,270 @@ export default function ExperienceCard({experience, onSave}: { experience: Exper
 
     const handleSave = () => {
         onSave(formData);
+        setIsEditing(false);
+    };
+
+    const handleCancel = () => {
+        if (!experience.id) {
+            // New unsaved card
+            onCancel?.();
+        } else {
+            // Existing card: reset and close
+            setFormData(experience);
+            setIsCurrent(experience.endDate === "Present");
+            setIsEditing(false);
+            onCancel?.();
+        }
+    };
+
+    const handleDelete = () => {
+        if (experience.id && onDelete) {
+            onDelete(experience.id);
+        }
+    };
+
+    const formatDate = (date: Date | 'Present' | undefined) => {
+        if (!date) return '';
+        if (date === 'Present') return 'Present';
+        return new Date(date).toLocaleDateString(undefined, { year: 'numeric', month: 'short' });
     };
 
     return (
-        <Card>
-            <CardHeader>
-                <CardTitle>
-                    <Input placeholder="Company name, Association name, ..." value={formData.company} onChange={(e) => setFormData({...formData, company: e.target.value})} />
-                </CardTitle>
-            </CardHeader>
-            <CardContent className="flex flex-col gap-2">
-                <InputGroup>
-                    <InputGroupInput placeholder="Job title" value={formData.jobTitle} onChange={(e) => setFormData({...formData, jobTitle: e.target.value})} />
-                    <InputGroupAddon><Building /></InputGroupAddon>
-                </InputGroup>
+        <Card className="relative overflow-hidden transition-all duration-300 hover:shadow-md border border-muted/80">
+            <AnimatePresence mode="wait">
+                {!isEditing ? (
+                    <motion.div
+                        key="view"
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -10 }}
+                        transition={{ duration: 0.2 }}
+                    >
+                        <CardHeader className="pb-2">
+                            <div className="flex items-start justify-between gap-4">
+                                <div className="space-y-1 flex-1">
+                                    <CardTitle className="text-xl font-bold tracking-tight text-foreground">
+                                        {formData.jobTitle || <span className="text-muted-foreground/50 italic">Untitled Position</span>}
+                                    </CardTitle>
+                                    <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground mt-1.5">
+                                        <span className="flex items-center gap-1.5 font-medium text-primary/95">
+                                            <Building className="h-4 w-4 shrink-0 text-primary/75" />
+                                            {formData.company || <span className="italic text-muted-foreground/50">Unnamed Company</span>}
+                                        </span>
+                                        {formData.location && (
+                                            <span className="flex items-center gap-1.5 text-muted-foreground/80">
+                                                <MapPin className="h-4 w-4 shrink-0" />
+                                                {formData.location}
+                                            </span>
+                                        )}
+                                    </div>
+                                </div>
 
-                <InputGroup>
-                    <InputGroupTextarea placeholder="Description" value={formData.description} onChange={(e) => setFormData({...formData, description: e.target.value})} />
-                    <InputGroupAddon><Building /></InputGroupAddon>
-                </InputGroup>
-
-                <InputGroup>
-                    <InputGroupInput placeholder="Location" value={formData.location} onChange={(e) => setFormData({...formData, location: e.target.value})} />
-                    <InputGroupAddon><LocationEdit /></InputGroupAddon>
-                </InputGroup>
-
-                <div>
-                    <Popover>
-                        From:
-                        <PopoverTrigger asChild>
-                            <Button variant={"outline"} data-empty={!formData.startDate} className="w-53 justify-between text-left font-normal data-[empty=true]:text-muted-foreground">
-                                {formData.startDate ? new Date(formData.startDate).toLocaleDateString(undefined, { year: 'numeric', month: 'short' }) : "Start date"}
-                                <ChevronDown />
+                                <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground/90 font-mono bg-muted/50 px-2.5 py-1 rounded-md shrink-0 border border-muted">
+                                    <LucideCalendar className="h-3.5 w-3.5" />
+                                    <span>{formatDate(formData.startDate)}</span>
+                                    <span>—</span>
+                                    <span>{formData.endDate === "Present" ? "Present" : formatDate(formData.endDate)}</span>
+                                </div>
+                            </div>
+                        </CardHeader>
+                        <CardContent className="pt-2 pb-4">
+                            {formData.description ? (
+                                <div className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap pl-4 border-l-2 border-primary/20 bg-muted/10 py-1 rounded-r-md">
+                                    {formData.description}
+                                </div>
+                            ) : (
+                                <p className="text-sm text-muted-foreground/50 italic pl-4 border-l-2 border-muted py-1">
+                                    No description provided.
+                                </p>
+                            )}
+                        </CardContent>
+                        <CardFooter className="pt-0 border-t border-muted/40 bg-muted/5 flex justify-end gap-2 py-3">
+                            <Button 
+                                variant="outline" 
+                                size="sm" 
+                                className="gap-1.5 hover:bg-background"
+                                onClick={() => setIsEditing(true)}
+                            >
+                                <Edit2 className="h-3.5 w-3.5" />
+                                Edit
                             </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                            <Calendar
-                                mode={"single"}
-                                selected={new Date(formData.startDate)}
-                                onSelect={(date: Date) => {setFormData({ ...formData, startDate: date})}}
-                                defaultMonth={formData.startDate}
-                                captionLayout="dropdown"
-                                required
-                            />
-                        </PopoverContent>
-                    </Popover>
-                    {!isCurrent && <Popover>
-                        To:
-                        <PopoverTrigger asChild>
-                            <Button variant={"outline"} data-empty={!formData.endDate} className="w-53 justify-between text-left font-normal data-[empty=true]:text-muted-foreground">
-                                {formData.endDate ? new Date(formData.endDate).toLocaleDateString(undefined, { year: 'numeric', month: 'short' }) : "End date"}
-                                <ChevronDown />
-                            </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                            <Calendar
-                                mode={"single"}
-                                selected={new Date(formData.endDate || new Date())}
-                                onSelect={(date: Date) => {setFormData({ ...formData, endDate: date})}}
-                                defaultMonth={formData.endDate === "Present" ? new Date() : formData.endDate}
-                                captionLayout="dropdown"
-                                required
-                            />
-                        </PopoverContent>
-                    </Popover>}
-                    <Checkbox className="ml-2" checked={isCurrent} onCheckedChange={(checked: boolean) => {
-                        setIsCurrent(checked);
-                        setFormData({ ...formData, endDate: checked ? "Present" : formData.endDate });
-                    }} /> Currently working here
-                    
-                </div>
+                        </CardFooter>
+                    </motion.div>
+                ) : (
+                    <motion.div
+                        key="edit"
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -10 }}
+                        transition={{ duration: 0.2 }}
+                    >
+                        <CardHeader className="pb-3">
+                            <CardTitle className="text-base font-semibold text-muted-foreground flex items-center gap-2">
+                                <Building className="h-4 w-4 text-primary" />
+                                {experience.id ? "Edit Experience" : "Add New Experience"}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="flex flex-col gap-3.5 pb-4">
+                            <div className="space-y-1.5">
+                                <label className="text-xs font-medium text-muted-foreground">Company or Organization</label>
+                                <Input 
+                                    placeholder="Company name, Association name, ..." 
+                                    value={formData.company} 
+                                    onChange={(e) => setFormData({...formData, company: e.target.value})} 
+                                />
+                            </div>
 
-                
-            </CardContent>
-            <CardFooter>
-                <Button variant="default" className="ml-auto" onClick={handleSave}>
-                    Save
-                </Button>
-            </CardFooter>
+                            <div className="space-y-1.5">
+                                <label className="text-xs font-medium text-muted-foreground">Job Title or Role</label>
+                                <InputGroup>
+                                    <InputGroupInput 
+                                        placeholder="Job title" 
+                                        value={formData.jobTitle} 
+                                        onChange={(e) => setFormData({...formData, jobTitle: e.target.value})} 
+                                    />
+                                    <InputGroupAddon><Building className="h-4 w-4" /></InputGroupAddon>
+                                </InputGroup>
+                            </div>
+
+                            <div className="space-y-1.5">
+                                <label className="text-xs font-medium text-muted-foreground">Role Description</label>
+                                <InputGroup>
+                                    <InputGroupTextarea 
+                                        placeholder="Describe your achievements and key responsibilities..." 
+                                        value={formData.description} 
+                                        onChange={(e) => setFormData({...formData, description: e.target.value})} 
+                                    />
+                                    <InputGroupAddon><Building className="h-4 w-4" /></InputGroupAddon>
+                                </InputGroup>
+                            </div>
+
+                            <div className="space-y-1.5">
+                                <label className="text-xs font-medium text-muted-foreground">Location</label>
+                                <InputGroup>
+                                    <InputGroupInput 
+                                        placeholder="Location (e.g. San Francisco, CA or Remote)" 
+                                        value={formData.location} 
+                                        onChange={(e) => setFormData({...formData, location: e.target.value})} 
+                                    />
+                                    <InputGroupAddon><MapPin className="h-4 w-4" /></InputGroupAddon>
+                                </InputGroup>
+                            </div>
+
+                            <div className="space-y-2 mt-1">
+                                <label className="text-xs font-medium text-muted-foreground block">Timeline</label>
+                                <div className="flex flex-wrap items-center gap-3">
+                                    <div className="flex items-center gap-2">
+                                        <span className="text-xs text-muted-foreground font-medium shrink-0">From:</span>
+                                        <Popover>
+                                            <PopoverTrigger asChild>
+                                                <Button 
+                                                    variant="outline" 
+                                                    data-empty={!formData.startDate} 
+                                                    className="w-48 justify-between text-left font-normal data-[empty=true]:text-muted-foreground"
+                                                >
+                                                    {formData.startDate ? new Date(formData.startDate).toLocaleDateString(undefined, { year: 'numeric', month: 'short' }) : "Start date"}
+                                                    <ChevronDown className="h-4 w-4 opacity-50" />
+                                                </Button>
+                                            </PopoverTrigger>
+                                            <PopoverContent className="w-auto p-0" align="start">
+                                                <Calendar
+                                                    mode="single"
+                                                    selected={new Date(formData.startDate)}
+                                                    onSelect={(date: Date) => {setFormData({ ...formData, startDate: date})}}
+                                                    defaultMonth={formData.startDate}
+                                                    captionLayout="dropdown"
+                                                    required
+                                                />
+                                            </PopoverContent>
+                                        </Popover>
+                                    </div>
+
+                                    {!isCurrent && (
+                                        <div className="flex items-center gap-2">
+                                            <span className="text-xs text-muted-foreground font-medium shrink-0">To:</span>
+                                            <Popover>
+                                                <PopoverTrigger asChild>
+                                                    <Button 
+                                                        variant="outline" 
+                                                        data-empty={!formData.endDate} 
+                                                        className="w-48 justify-between text-left font-normal data-[empty=true]:text-muted-foreground"
+                                                    >
+                                                        {formData.endDate ? new Date(formData.endDate).toLocaleDateString(undefined, { year: 'numeric', month: 'short' }) : "End date"}
+                                                        <ChevronDown className="h-4 w-4 opacity-50" />
+                                                    </Button>
+                                                </PopoverTrigger>
+                                                <PopoverContent className="w-auto p-0" align="start">
+                                                    <Calendar
+                                                        mode="single"
+                                                        selected={new Date(formData.endDate || new Date())}
+                                                        onSelect={(date: Date) => {setFormData({ ...formData, endDate: date})}}
+                                                        defaultMonth={formData.endDate === "Present" ? new Date() : formData.endDate}
+                                                        captionLayout="dropdown"
+                                                        required
+                                                    />
+                                                </PopoverContent>
+                                            </Popover>
+                                        </div>
+                                    )}
+
+                                    <div className="flex items-center gap-2 ml-1">
+                                        <Checkbox 
+                                            id={`current-${experience.id || 'new'}`}
+                                            checked={isCurrent} 
+                                            onCheckedChange={(checked: boolean) => {
+                                                setIsCurrent(checked);
+                                                setFormData({ ...formData, endDate: checked ? "Present" : undefined });
+                                            }} 
+                                        />
+                                        <label 
+                                            htmlFor={`current-${experience.id || 'new'}`}
+                                            className="text-xs font-medium text-muted-foreground select-none cursor-pointer"
+                                        >
+                                            Currently working here
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </CardContent>
+                        <CardFooter className="border-t border-muted/40 bg-muted/5 flex items-center justify-between py-3">
+                            <div>
+                                {experience.id && onDelete && (
+                                    <Button 
+                                        variant="ghost" 
+                                        size="sm" 
+                                        className="text-destructive hover:text-destructive hover:bg-destructive/10 gap-1.5"
+                                        onClick={handleDelete}
+                                    >
+                                        <Trash2 className="h-3.5 w-3.5" />
+                                        Delete
+                                    </Button>
+                                )}
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <Button 
+                                    variant="outline" 
+                                    size="sm" 
+                                    className="gap-1.5"
+                                    onClick={handleCancel}
+                                >
+                                    <X className="h-3.5 w-3.5" />
+                                    Cancel
+                                </Button>
+                                <Button 
+                                    variant="default" 
+                                    size="sm" 
+                                    className="gap-1.5 shadow-sm"
+                                    onClick={handleSave}
+                                >
+                                    <Save className="h-3.5 w-3.5" />
+                                    Save
+                                </Button>
+                            </div>
+                        </CardFooter>
+                    </motion.div>
+                )}
+            </AnimatePresence>
         </Card>
     );
 }

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -130,7 +130,7 @@ function Calendar({
         ),
         hidden: cn("invisible", defaultClassNames.hidden),
         ...classNames,
-      }}
+      } as any}
       components={{
         Root: ({ className, rootRef, ...props }) => {
           return (


### PR DESCRIPTION
## Summary
Split ExperienceCard into View and Edit modes

## Changes
- Implemented state toggle (isEditing) in ExperienceCard for a cleaner static View layout
- Added fully functional 'Cancel' (resets state) and 'Delete' store-linked capabilities
- Programmed new experience entries to mount directly into Edit Mode by default
- Enhanced toggle transitions and entry lists with smooth framer-motion animations


Closes #12