### PR TITLE
4 refactor hook vectorservice background indexing into the updatesection pipeline

### DIFF
--- a/electron/functions/updateSection.ts
+++ b/electron/functions/updateSection.ts
@@ -2,6 +2,9 @@ import { ProfilesData } from "../../shared/profilesData.interface";
 import * as fs from 'fs';
 import { profilesDir } from "../main.dev";
 import path from "path/win32";
+import { VectorService } from "../services/VectorService";
+import { Experience } from "../../shared/Experience.interface";
+import { Project } from "../../shared/projects.interface";
 
 const SECTION_FILE_MAP: Record<keyof ProfilesData, string> = {
     education: 'edu.json',
@@ -17,13 +20,23 @@ export async function updateSection<K extends keyof ProfilesData>(id: string, se
     if (!fileName) {
         throw new Error(`Section ${section} unknown.`);
     }
-    const filePath = path.join(profilesDir, id, fileName);
+    const profilePath = path.join(profilesDir, id);
+    const filePath = path.join(profilePath, fileName);
     try {
         await fs.promises.writeFile(
             filePath, 
             JSON.stringify(newData, null, 2), 
             'utf-8'
         );
+        const vectorService = VectorService.getInstance();
+
+        if (section === 'experience') {
+            vectorService.syncExperiences(profilePath, newData as Experience[])
+                .catch(err => console.error("[UpdateSection] Error syncing experiences:", err));
+        } else if (section === 'projects') {
+            vectorService.syncProjects(profilePath, newData as Project[])
+                .catch(err => console.error("[UpdateSection] Error syncing projects:", err));
+        }
         return newData;
     } catch (err) {
         console.error(`Error writing ${fileName}:`, err);

--- a/electron/services/VectorService.ts
+++ b/electron/services/VectorService.ts
@@ -28,7 +28,7 @@ export class VectorService {
   }
 
   /**
-   * Initialise le modèle d'embedding (une seule fois)
+   * Initialize the embedding model
    */
   private async initModel() {
     if (!this.embedder) {
@@ -39,7 +39,7 @@ export class VectorService {
   }
 
   /**
-   * Transforme un texte en vecteur
+   * text to vector using the embedding model
    */
   public async generateEmbedding(text: string): Promise<Float32Array> {
     await this.initModel();
@@ -49,7 +49,7 @@ export class VectorService {
   }
 
   /**
-   * 1. Ranking des Expériences (Simple)
+   * Experiences ranking (Simple)
    */
   public async rankExperiences(jobDescription: string, topK: number = 3) {
     const queryVector = await this.generateEmbedding(jobDescription);
@@ -95,22 +95,28 @@ export class VectorService {
     };
   }
 
+  /**
+   * Clear and rebuild the entire vector index for a profile (used during sync)
+   * @param profilePath Path to the profile's data directory
+   * @param experiences to index
+   * @param projects to index
+   */
   async rebuildVectorIndex(profilePath: string, experiences: Experience[], projects: Project[]) {
     const db = VectorDatabase.getInstance();
 
     db.connect(profilePath);
     db.clearAll();
     
-    console.log("Starting sync...");
+    console.log("[VectorService] Starting sync...");
 
     for (const exp of experiences) {
-      const text = `${exp.jobTitle} chez ${exp.company}. ${exp.description || ''}`;
+      const text = `${exp.jobTitle}: ${exp.description || ''}`;
       const vector = await this.generateEmbedding(text);
       db.upsertExperience(exp.id, Buffer.from(vector.buffer));
     }
 
     for (const proj of projects) {
-      const projText = `${proj.title} ${proj.subtitle || ''}`;
+      const projText = `${proj.title} ${proj.subtitle ? '- '+proj.subtitle : ''}`;
       const projVector = await this.generateEmbedding(projText);
       
       const sqlProjId = db.upsertProject(proj.id, Buffer.from(projVector.buffer));
@@ -122,6 +128,53 @@ export class VectorService {
       }
     }
 
-    console.log("Indexation done !");
+    console.log("[VectorService] Indexation done !");
+  }
+
+  /**
+   * Sync experiences (used when modifying an experience)
+   * @param profilePath path to the profile's data directory
+   * @param experiences to index
+   */
+  async syncExperiences(profilePath: string, experiences: Experience[]) {
+    const db = VectorDatabase.getInstance();
+    db.connect(profilePath);
+    
+    db.clearExperiences();
+
+    console.log("[VectorService] Indexing experiences...");
+    for (const exp of experiences) {
+        const text = `${exp.jobTitle}: ${exp.description || ''}`;
+        const vector = await this.generateEmbedding(text);
+        db.upsertExperience(exp.id, Buffer.from(vector.buffer));
+    }
+    console.log("[VectorService] Experiences indexed successfully!");
+  }
+
+  /**
+   * Sync projects and bullets (used when modifying a project or a bullet)
+   * @param profilePath path to the profile's data directory
+   * @param projects to index
+   */
+  async syncProjects(profilePath: string, projects: Project[]) {
+    const db = VectorDatabase.getInstance();
+    db.connect(profilePath);
+    
+    db.clearProjectsAndBullets();
+
+    console.log("[VectorService] Indexing projects and bullets...");
+    for (const proj of projects) {
+        const projText = `${proj.title} ${proj.subtitle ? '- '+proj.subtitle : ''}`;
+        const projVector = await this.generateEmbedding(projText);
+        
+        const sqlProjId = db.upsertProject(proj.id, Buffer.from(projVector.buffer));
+
+        for (const bullet of proj.bullets) {
+            const bulletText = `${bullet.text} ${bullet.tags.join(' ')}`;
+            const bulletVector = await this.generateEmbedding(bulletText);
+            db.upsertProjectBullet(sqlProjId, bullet.id, Buffer.from(bulletVector.buffer));
+        }
+    }
+    console.log("[VectorService] Projects indexed successfully!");
   }
 }

--- a/electron/services/VectorService.ts
+++ b/electron/services/VectorService.ts
@@ -122,7 +122,7 @@ export class VectorService {
       const sqlProjId = db.upsertProject(proj.id, Buffer.from(projVector.buffer));
 
       for (const bullet of proj.bullets) {
-        const bulletText = `${bullet.text} ${bullet.tags.join(' ')}`;
+        const bulletText = `${bullet.text} (${bullet.tags.join(' ')})`;
         const bulletVector = await this.generateEmbedding(bulletText);
         db.upsertProjectBullet(sqlProjId, bullet.id, Buffer.from(bulletVector.buffer));
       }
@@ -170,7 +170,7 @@ export class VectorService {
         const sqlProjId = db.upsertProject(proj.id, Buffer.from(projVector.buffer));
 
         for (const bullet of proj.bullets) {
-            const bulletText = `${bullet.text} ${bullet.tags.join(' ')}`;
+            const bulletText = `${bullet.text} (${bullet.tags.join(' ')})`;
             const bulletVector = await this.generateEmbedding(bulletText);
             db.upsertProjectBullet(sqlProjId, bullet.id, Buffer.from(bulletVector.buffer));
         }

--- a/electron/services/vectorDatabase.ts
+++ b/electron/services/vectorDatabase.ts
@@ -17,7 +17,7 @@ export class VectorDatabase {
   }
 
   /**
-   * Initialise or change the database connection based on the profile
+   * Initialize or change the database connection based on the profile
    */
   public connect(profilePath: string): void {
     if (this.currentProfilePath === profilePath && this.db) return;
@@ -45,6 +45,25 @@ export class VectorDatabase {
       VACUUM;
     `);
     console.log('[VectorDatabase] All vector data cleared from the database');
+  }
+
+  public clearExperiences(): void {
+    if (!this.db) return;
+    this.db.exec(`
+      DELETE FROM idx_experiences;
+      VACUUM;
+    `);
+    console.log('[VectorDatabase] Experience vectors cleared from the database');
+  }
+
+  public clearProjectsAndBullets(): void {
+    if (!this.db) return;
+    this.db.exec(`
+      DELETE FROM idx_project_bullets;
+      DELETE FROM idx_projects;
+      VACUUM;
+    `);
+    console.log('[VectorDatabase] Project and bullet vectors cleared from the database');
   }
 
   private initSchema(): void {
@@ -123,7 +142,7 @@ export class VectorDatabase {
   }
 
   /**
-   * Upsert d'une expérience (bloc unique)
+   * Upsert an experience vector using local_id to detect conflicts
    */
   public upsertExperience(localId: string, vector: Buffer): void {
     if (!this.db) throw new Error("Database not connected");
@@ -140,7 +159,7 @@ export class VectorDatabase {
   }
 
   /**
-   * Récupère tous les vecteurs d'expériences pour le matching
+   * Retrieve all experience vectors for matching
    */
   public getAllExperiences(): { local_id: string, vector: Buffer }[] {
     if (!this.db) return [];


### PR DESCRIPTION
## Description
Automated the semantic database synchronization whenever a user saves their **Experiences** or **Projects**, making the manual "Sync" button optional. 

## Key Changes
* **Non-blocking UI:** The vector embedding generation runs asynchronously in the background. The frontend saves instantly via the JSON file write without any lag or freezing.
* **Granular Re-indexing:** Replaced the global `db.clearAll()` wipe with targeted section updates (`syncExperiences` / `syncProjects`) to only re-index what actually changed.
* **Optimized Strings:** Refructured project and experience strings passed to the `all-MiniLM-L6-v2` model to maximize semantic search accuracy.
> Note: we kept the syncDb option in case the database is not synced, but we should maybe move the button somewhere else.

Closes #4 