### PR TITLE
Add Ctrl/Cmd+N shortcut to add a new entry (Education, Experience, Project)

### DIFF
--- a/src/components/mainPannels/education/Education.tsx
+++ b/src/components/mainPannels/education/Education.tsx
@@ -1,12 +1,16 @@
 import { useProfileStore } from "@/store/profile";
 import EducationCard from "./EducationCard";
 import type { Education } from "@shared/Education.interface";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { motion } from "framer-motion";
+import { getModifierKeyLabel, useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 
 export default function Education() {
     const { education, updateSection } = useProfileStore();
     const [ addNew, setAddNew ] = useState(false);
+
+    const handleAddShortcut = useCallback(() => setAddNew(true), []);
+    useKeyboardShortcut("n", handleAddShortcut, { enabled: !addNew });
 
     const handleOnSave = (updatedEducation: Education) => {
         const newEducationList = education.map((edu) => edu.id === updatedEducation.id ? updatedEducation : edu);
@@ -36,9 +40,10 @@ export default function Education() {
             ) : (
                 <button
                     onClick={() => setAddNew(true)}
-                    className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+                    className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-flex items-center gap-2 w-fit"
                 >
                     Add Education
+                    <kbd className="text-xs font-normal bg-blue-700/60 px-1.5 py-0.5 rounded">{getModifierKeyLabel()}+N</kbd>
                 </button>
             )}
         </motion.div>

--- a/src/components/mainPannels/experiences/Experience.tsx
+++ b/src/components/mainPannels/experiences/Experience.tsx
@@ -1,12 +1,16 @@
 import { useProfileStore } from "@/store/profile";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import type { Experience } from "@shared/Experience.interface";
 import ExperienceCard from "./ExperienceCard";
+import { getModifierKeyLabel, useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 
 export default function ExperienceComponent() {
     const { experience, updateSection } = useProfileStore();
     const [ addNew, setAddNew ] = useState(false);
+
+    const handleAddShortcut = useCallback(() => setAddNew(true), []);
+    useKeyboardShortcut("n", handleAddShortcut, { enabled: !addNew });
 
     const handleOnSave = (updatedExperience: Experience) => {
         const newExperienceList = experience.map((exp) => exp.id === updatedExperience.id ? updatedExperience : exp);
@@ -72,9 +76,10 @@ export default function ExperienceComponent() {
             {!addNew && (
                 <button
                     onClick={() => setAddNew(true)}
-                    className="bg-primary hover:bg-primary/70 text-white font-bold py-2 px-4 rounded transition-colors duration-200 mt-2"
+                    className="bg-primary hover:bg-primary/70 text-white font-bold py-2 px-4 rounded transition-colors duration-200 mt-2 inline-flex items-center gap-2 w-fit"
                 >
                     Add Experience
+                    <kbd className="text-xs font-normal bg-black/20 px-1.5 py-0.5 rounded">{getModifierKeyLabel()}+N</kbd>
                 </button>
             )}
         </motion.div>

--- a/src/components/mainPannels/projects/Project.tsx
+++ b/src/components/mainPannels/projects/Project.tsx
@@ -1,14 +1,18 @@
 import { useProfileStore } from "@/store/profile";
 import type { Project } from "@shared/projects.interface";
 import { AnimatePresence, motion } from "framer-motion";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import ProjectCard from "./ProjectCard";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
+import { getModifierKeyLabel, useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 
 export default function ProjectComponent() {
     const { projects, updateSection } = useProfileStore();
     const [ addNew, setAddNew ] = useState(false);
+
+    const handleAddShortcut = useCallback(() => setAddNew(true), []);
+    useKeyboardShortcut("n", handleAddShortcut, { enabled: !addNew });
 
     const handleOnSave = (updatedProject: Project) => {
         const newProjectList = projects.map((project) => project.id === updatedProject.id ? updatedProject : project);
@@ -80,6 +84,7 @@ export default function ProjectComponent() {
                     className="h-12 w-full rounded-xl border-dashed text-muted-foreground hover:text-foreground"
                     >
                     <Plus size={16} className="mr-2" /> Add Project
+                    <kbd className="ml-2 text-xs bg-muted-foreground/10 px-1.5 py-0.5 rounded">{getModifierKeyLabel()}+N</kbd>
                     </Button>
                 </motion.div>
                 )}

--- a/src/hooks/use-keyboard-shortcut.ts
+++ b/src/hooks/use-keyboard-shortcut.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+
+/** Returns "⌘" on macOS and "Ctrl" everywhere else, for shortcut hints in the UI. */
+export function getModifierKeyLabel(): string {
+    if (typeof navigator === "undefined") return "Ctrl";
+    return /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? "⌘" : "Ctrl";
+}
+
+interface UseKeyboardShortcutOptions {
+    /** Require Ctrl (Windows/Linux) or Cmd (macOS) to be held. Defaults to true. */
+    ctrlOrCmd?: boolean;
+    /** Set to false to temporarily disable the shortcut without unmounting the hook. */
+    enabled?: boolean;
+}
+
+/**
+ * Registers a global keydown shortcut for as long as the calling component is mounted.
+ * Used to give each profile panel its own "add new entry" shortcut (e.g. Ctrl/Cmd+N)
+ * without duplicating keydown-listener boilerplate in every panel.
+ */
+export function useKeyboardShortcut(
+    key: string,
+    callback: () => void,
+    options: UseKeyboardShortcutOptions = {}
+) {
+    const { ctrlOrCmd = true, enabled = true } = options;
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            const modifierSatisfied = ctrlOrCmd ? event.ctrlKey || event.metaKey : true;
+            if (modifierSatisfied && event.key.toLowerCase() === key.toLowerCase()) {
+                event.preventDefault();
+                callback();
+            }
+        };
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [key, callback, ctrlOrCmd, enabled]);
+}


### PR DESCRIPTION
Closes #34.

## What
Adds a `useKeyboardShortcut(key, callback, options)` hook (`src/hooks/use-keyboard-shortcut.ts`, following the existing `use-mobile.ts` naming convention) and wires it into the three panels named in the issue:

- `src/components/mainPannels/education/Education.tsx`
- `src/components/mainPannels/experiences/Experience.tsx` (the issue's checklist named `ExperienceComponent.tsx`, but the actual file/exported component is `Experience.tsx` / `ExperienceComponent` — same component either way)
- `src/components/mainPannels/projects/Project.tsx`

Pressing Ctrl+N (Cmd+N on macOS) now triggers the same "add new entry" action as each panel's existing Add button, with `preventDefault()` so it doesn't trigger the browser's own new-window shortcut. The shortcut is disabled while a panel is already in "adding" mode, mirroring the existing Add button (which is likewise hidden/disabled during that state).

Each Add button also gets a small `<kbd>` badge showing the shortcut, using a `getModifierKeyLabel()` helper (also exported from the hook file) that shows "⌘" on macOS and "Ctrl" elsewhere.

## Why a hook instead of copy-pasted `useEffect`s
The issue offered both options; went with the hook since all three panels needed the exact same "Ctrl/Cmd + key, unless disabled" logic, and it's one place to fix if the behavior needs to change later (e.g. the modifier-key detection).

## Testing
- `npm run typecheck` — passes, no errors.
- `npx eslint` on the four changed/added files — no warnings or errors.
- Manually reasoned through each panel's state: the callback is memoized with `useCallback` and the hook's `enabled` flag flips with `addNew`, so the listener is added/removed correctly as each panel toggles in and out of "adding" mode.