### PR TITLE
feat: support bold formatting in CV template fields

### DIFF
--- a/src/components/cvMaker/cvTemplate/templateFields/TemplateInput.tsx
+++ b/src/components/cvMaker/cvTemplate/templateFields/TemplateInput.tsx
@@ -2,6 +2,8 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useCVSelection } from "../../provider/hook";
 import { TemplateSkeleton } from './TemplateSkeleton';
 import type { EntityType } from '@shared/utils';
+import { toggleBold } from "../utils/toggleBold";
+import { renderFormattedText } from "../utils/renderFormattedText";
 
 interface FieldProps {
   entityType: EntityType;
@@ -45,9 +47,42 @@ export function TemplateInput({
     updateCustomField(entityType, id, field, tempValue);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') handleBlur();
-    if (e.key === 'Escape') {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (
+      (e.ctrlKey || e.metaKey) &&
+      e.key.toLowerCase() === "b"
+    ) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const selectionStart = e.currentTarget.selectionStart ?? 0;
+      const selectionEnd =
+        e.currentTarget.selectionEnd ?? selectionStart;
+
+      const result = toggleBold(
+        tempValue,
+        selectionStart,
+        selectionEnd,
+      );
+
+      setTempValue(result.value);
+
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.setSelectionRange(
+          result.selectionStart,
+          result.selectionEnd,
+        );
+      });
+
+      return;
+    }
+
+    if (e.key === "Enter") {
+      handleBlur();
+    }
+
+    if (e.key === "Escape") {
       setTempValue(value);
       setIsEditing(false);
     }
@@ -81,7 +116,10 @@ export function TemplateInput({
       title="Cliquer pour modifier"
       className={`cursor-text hover:bg-slate-100 rounded px-0.5 transition-colors print:hover:bg-transparent ${className}`}
     >
-      {value || <span className="italic opacity-40">{placeholder}</span>}
+      {value
+        ? renderFormattedText(value)
+        : <span className="italic opacity-40">{placeholder}</span>
+      }
     </span>
   );
 }

--- a/src/components/cvMaker/cvTemplate/templateFields/TemplateTextArea.tsx
+++ b/src/components/cvMaker/cvTemplate/templateFields/TemplateTextArea.tsx
@@ -1,8 +1,15 @@
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import { useCVSelection } from "../../provider/hook";
 import { Sparkles } from "lucide-react";
 import { TemplateSkeleton } from "./TemplateSkeleton";
 import type { EntityType } from "@shared/utils";
+import { toggleBold } from "../utils/toggleBold";
+import { renderFormattedText } from "../utils/renderFormattedText";
 
 interface FieldProps {
   entityType: EntityType;
@@ -45,6 +52,39 @@ export function TemplateTextArea({
     updateCustomField(entityType, id, field, tempValue);
   };
 
+  const handleKeyDown = (
+    event: KeyboardEvent<HTMLTextAreaElement>,
+  ) => {
+    if (
+      (event.ctrlKey || event.metaKey) &&
+      event.key.toLowerCase() === "b"
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const selectionStart =
+        event.currentTarget.selectionStart ?? 0;
+      const selectionEnd =
+        event.currentTarget.selectionEnd ?? selectionStart;
+
+      const result = toggleBold(
+        tempValue,
+        selectionStart,
+        selectionEnd,
+      );
+
+      setTempValue(result.value);
+
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+        textareaRef.current?.setSelectionRange(
+          result.selectionStart,
+          result.selectionEnd,
+        );
+      });
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="flex items-center gap-2 py-0.5">
@@ -61,7 +101,8 @@ export function TemplateTextArea({
         value={tempValue}
         onChange={(e) => setTempValue(e.target.value)}
         onBlur={handleBlur}
-        rows={Math.max(2, tempValue.split('\n').length)}
+        onKeyDown={handleKeyDown}
+        rows={Math.max(2, tempValue.split("\n").length)}
         className={`w-full bg-amber-50/80 border border-amber-400 rounded p-1 outline-none text-justify resize-none animate-in fade-in duration-100 print:hidden ${className}`}
       />
     );
@@ -73,7 +114,10 @@ export function TemplateTextArea({
       title="Cliquer pour modifier"
       className={`cursor-pointer hover:bg-slate-100 rounded px-0.5 transition-colors whitespace-pre-line text-justify print:hover:bg-transparent ${className}`}
     >
-      {value || <span className="italic opacity-40">{placeholder}</span>}
+      {value
+        ? renderFormattedText(value)
+        : <span className="italic opacity-40">{placeholder}</span>
+      }
     </p>
   );
 }

--- a/src/components/cvMaker/cvTemplate/utils/renderFormattedText.tsx
+++ b/src/components/cvMaker/cvTemplate/utils/renderFormattedText.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+export function renderFormattedText(text: string): ReactNode[] {
+  const parts: ReactNode[] = [];
+  const boldPattern = /\*\*([\s\S]+?)\*\*/g;
+
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = boldPattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+
+    parts.push(
+      <strong key={`bold-${match.index}`} className="font-bold">
+        {match[1]}
+      </strong>,
+    );
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts;
+}

--- a/src/components/cvMaker/cvTemplate/utils/toggleBold.ts
+++ b/src/components/cvMaker/cvTemplate/utils/toggleBold.ts
@@ -1,0 +1,67 @@
+export interface BoldToggleResult {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+export function toggleBold(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+): BoldToggleResult {
+  // No selection: insert **** and put the cursor in the middle.
+  if (selectionStart === selectionEnd) {
+    const nextValue =
+      value.slice(0, selectionStart) +
+      "****" +
+      value.slice(selectionEnd);
+
+    return {
+      value: nextValue,
+      selectionStart: selectionStart + 2,
+      selectionEnd: selectionStart + 2,
+    };
+  }
+
+  const selectedText = value.slice(selectionStart, selectionEnd);
+
+  // The selection itself contains **text**.
+  if (selectedText.startsWith("**") && selectedText.endsWith("**")) {
+    const unwrappedText = selectedText.slice(2, -2);
+
+    return {
+      value:
+        value.slice(0, selectionStart) +
+        unwrappedText +
+        value.slice(selectionEnd),
+      selectionStart,
+      selectionEnd: selectionStart + unwrappedText.length,
+    };
+  }
+
+  // The selected text is surrounded by ** markers.
+  const hasOuterMarkers =
+    value.slice(selectionStart - 2, selectionStart) === "**" &&
+    value.slice(selectionEnd, selectionEnd + 2) === "**";
+
+  if (hasOuterMarkers) {
+    return {
+      value:
+        value.slice(0, selectionStart - 2) +
+        selectedText +
+        value.slice(selectionEnd + 2),
+      selectionStart: selectionStart - 2,
+      selectionEnd: selectionEnd - 2,
+    };
+  }
+
+  // Otherwise, make the selected text bold.
+  return {
+    value:
+      value.slice(0, selectionStart) +
+      `**${selectedText}**` +
+      value.slice(selectionEnd),
+    selectionStart: selectionStart + 2,
+    selectionEnd: selectionEnd + 2,
+  };
+}


### PR DESCRIPTION
## Summary

- add Ctrl+B/Cmd+B bold toggling to TemplateInput and TemplateTextArea
- support wrapping and unwrapping selected text with Markdown `**` markers
- insert `****` with the cursor positioned in the middle when no text is selected
- render Markdown bold text using `<strong className="font-bold">`
- preserve unformatted text
- prevent the template shortcut from triggering the sidebar shortcut

Closes #41

## Testing

- `npm run lint`
- `npm run typecheck`
- manually tested selected-text wrapping
- manually tested removing bold formatting
- manually tested empty-selection cursor placement
- manually tested TemplateInput and TemplateTextArea
- manually verified bold formatting in display mode