### PR TITLE
feat/cover-letter-pdf-export

### DIFF
--- a/src/components/cvMaker/Maker.tsx
+++ b/src/components/cvMaker/Maker.tsx
@@ -41,7 +41,7 @@ export default function Maker() {
                             {coverLetterActive ? <CoverLetterTemplate /> : <CVTemplate />}
                         </div>
                     </div>
-                    <ToolsButtons openPicker={() => setPickerOpen(true)} />
+                    <ToolsButtons openPicker={() => setPickerOpen(true)} coverLetterActive={coverLetterActive} />
                     {pickerOpen && <CvPicker onClose={() => setPickerOpen(false)} />}
                     { coverLetterActive && <CoverLetterButtons />}
                 </div>

--- a/src/components/cvMaker/ToolsButtons.tsx
+++ b/src/components/cvMaker/ToolsButtons.tsx
@@ -1,15 +1,27 @@
 import { Download, Save, SidebarClose } from "lucide-react";
 import { Button } from "../ui/button";
 import { exportToPdf } from "./cvTemplate/exportCV";
+import { exportCoverLetterToPdf } from "./coverLetter/exportCoverLetter";
 import { useState } from "react";
 import { useCVSelection } from "./provider/hook";
+import useCoverLetterContext from "./CoverLetterProvider/hook";
 
-export default function ToolsButtons({ openPicker }: { openPicker: () => void }) {
+interface ToolsButtonsProps {
+    openPicker: () => void;
+    coverLetterActive?: boolean;
+}
+
+export default function ToolsButtons({ openPicker, coverLetterActive = false }: ToolsButtonsProps) {
     const [isExporting, setIsExporting] = useState(false);
     const { title, save, isSaving } = useCVSelection();
+    const { coverLetter } = useCoverLetterContext();
+
     const handleExport = async () => {
         setIsExporting(true);
-        exportToPdf(title).finally(() => setIsExporting(false));
+        const exporting = coverLetterActive
+            ? exportCoverLetterToPdf(coverLetter?.companyName, coverLetter?.roleName)
+            : exportToPdf(title);
+        exporting.finally(() => setIsExporting(false));
     };
     
     return (

--- a/src/components/cvMaker/coverLetter/exportCoverLetter.ts
+++ b/src/components/cvMaker/coverLetter/exportCoverLetter.ts
@@ -1,0 +1,96 @@
+import { api } from "@/api";
+import { toast } from "sonner";
+
+const COVER_LETTER_ELEMENT_ID = "cover-letter-content";
+
+/**
+ * Collect every rule of the currently applied stylesheets so the offscreen
+ * print window renders with the same Tailwind / CSS output as the preview.
+ */
+const collectDocumentStyles = () =>
+  Array.from(document.styleSheets)
+    .map((styleSheet) => {
+      try {
+        return Array.from(styleSheet.cssRules)
+          .map((rule) => rule.cssText)
+          .join("");
+      } catch (e) {
+        console.warn("Could not read stylesheet rules", e);
+        return "";
+      }
+    })
+    .join("\n");
+
+/** Strip the characters that are not allowed in a file name. */
+const sanitizeFileNamePart = (value: string) =>
+  value.replace(/[\/:*?"<>|]/g, "").replace(/\s+/g, " ").trim();
+
+const buildFileName = (companyName?: string, roleName?: string) => {
+  const parts = ["Cover Letter", companyName, roleName]
+    .map((part) => (part ? sanitizeFileNamePart(part) : ""))
+    .filter(Boolean);
+
+  return `${parts.join(" - ")}.pdf`;
+};
+
+export const exportCoverLetterToPdf = async (companyName?: string, roleName?: string) => {
+  const element = document.getElementById(COVER_LETTER_ELEMENT_ID);
+  if (!element) {
+    toast.error("Cover letter not found, open it before exporting.");
+    return false;
+  }
+
+  const styleContent = collectDocumentStyles();
+
+  const fullHTML = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Cover Letter</title>
+        <meta charset="utf-8">
+        <style>
+          ${styleContent}
+          body { margin: 0; padding: 0; background: #fff; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+          #${COVER_LETTER_ELEMENT_ID} { box-shadow: none !important; border: none !important; margin: 0 auto !important; }
+          .hidden-print { display: none !important; }
+
+          @media print {
+            /* the global print rules only reveal #cv-content, opt the cover letter in */
+            body * { visibility: hidden; }
+            #${COVER_LETTER_ELEMENT_ID}, #${COVER_LETTER_ELEMENT_ID} * { visibility: visible !important; }
+            #${COVER_LETTER_ELEMENT_ID} {
+              width: 100% !important;
+              min-height: 0 !important;
+              box-shadow: none !important;
+              border: none !important;
+              padding: 0 !important;
+              margin: 0 !important;
+              background: transparent !important;
+            }
+            .hidden-print { display: none !important; }
+
+            @page {
+              size: A4;
+              margin: 15mm !important;
+            }
+          }
+        </style>
+      </head>
+      <body>
+        ${element.outerHTML}
+      </body>
+    </html>
+  `;
+
+  try {
+    const success = await api.generatePDF(fullHTML, buildFileName(companyName, roleName));
+    // the IPC handler also returns false when the save dialog is dismissed
+    if (success) toast.success("Cover letter exported successfully!");
+    else toast.error("Cover letter export cancelled or failed.");
+    return success;
+  } catch (e: unknown) {
+    console.error("Error exporting cover letter:", e);
+    toast.error("Cover letter export failed.");
+    return false;
+  }
+};

--- a/src/components/cvMaker/coverLetter/exportCoverLetter.ts
+++ b/src/components/cvMaker/coverLetter/exportCoverLetter.ts
@@ -23,7 +23,7 @@ const collectDocumentStyles = () =>
 
 /** Strip the characters that are not allowed in a file name. */
 const sanitizeFileNamePart = (value: string) =>
-  value.replace(/[\/:*?"<>|]/g, "").replace(/\s+/g, " ").trim();
+  value.replace(/[/:*?"<>|]/g, "").replace(/\s+/g, " ").trim();
 
 const buildFileName = (companyName?: string, roleName?: string) => {
   const parts = ["Cover Letter", companyName, roleName]


### PR DESCRIPTION
# feat: PDF export for cover letter

Closes #59

## Summary

Adds A4 PDF export for the generated cover letter, reusing the existing Electron
`generatePDF` IPC service. Follows the pattern already established by
`cvTemplate/exportCV.ts`.

## Changes

### `src/components/cvMaker/coverLetter/exportCoverLetter.ts` (new)

`exportCoverLetterToPdf(companyName?, roleName?)`:

- Resolves the `#cover-letter-content` DOM node; toasts an error and bails if the
  cover letter view isn't mounted.
- Aggregates every rule from `document.styleSheets` so Tailwind / app CSS is
  preserved in the offscreen print window (same `try/catch` guard as `exportCV.ts`,
  since cross-origin sheets throw on `cssRules`).
- Builds a full HTML document from those styles + reset/print overrides + the
  element's `outerHTML`.
- Sends it to `api.generatePDF` with a sanitized filename:
  `Cover Letter - [Company] - [Role].pdf` (illegal Windows path characters
  stripped, missing parts dropped).
- Emits `sonner` toasts on success, on failure/cancel, and on a thrown IPC error.

### `src/components/cvMaker/ToolsButtons.tsx`

The single "Export PDF" button renders in both the resume and cover letter views,
so it was silently exporting the CV while the cover letter was on screen. It is
now view-aware: a new optional `coverLetterActive` prop routes the click to
`exportCoverLetterToPdf(coverLetter?.companyName, coverLetter?.roleName)` — pulled
from `useCoverLetterContext` — or to `exportToPdf(title)` as before. The existing
`isExporting` state drives the "Generating..." label for both paths.

### `src/components/cvMaker/Maker.tsx`

Passes `coverLetterActive` down to `ToolsButtons`.

## Print-CSS notes

The global `@media print` block in `src/index.css` sets `body * { visibility: hidden }`
and re-reveals only `#cv-content`. Because the exported document carries every app
stylesheet, the cover letter would otherwise have rendered as a **blank PDF**. The
export module therefore:

- Opts `#cover-letter-content` (and its descendants) back into `visibility: visible`.
- Mirrors the `#cv-content` print rules — `padding: 0`, `width: 100%`,
  `min-height: 0`, no shadow/border — so the page margin comes from
  `@page { size: A4; margin: 15mm }` rather than the element's own `p-[15mm]`.
  Without this the margins would double to 30mm.
- Suppresses `.hidden-print`, which removes the red "End of page" preview marker.
  The inline edit textarea already carries `print:hidden`.

## Acceptance criteria

- [x] Clicking "Export PDF" triggers the Electron PDF generator without visual breakage.
- [x] PDF margins, colors, and typography match the on-screen preview
      (`printBackground` + `-webkit-print-color-adjust: exact`, 15mm A4 page margin).
- [x] Decorative preview elements (page-break marker, borders, box shadows) are
      suppressed in the output.
- [x] Toast notifications confirm success and failure.

## Deviation from the issue

The issue asked to bind the export to the cover letter view component. Since the
only "Export PDF" button lives in the shared `ToolsButtons` toolbar, it was made
view-aware instead of adding a second export button to `CoverLetterButtons`. Happy
to switch to a dedicated button if preferred.

## Testing

`node_modules` was not installed in this checkout, so `npm run typecheck` and a
manual run of the app were not performed. A standalone `tsc` parse over the three
touched files surfaced only the expected `react/jsx-runtime` module-resolution
errors from the missing dependencies. **The generated PDF has not yet been visually
compared against the preview** — worth a manual check before merge.
