### PR TITLE
feat(ui): add ctrl+s shortcut to save resume (#70)

### DIFF
--- a/src/components/cvMaker/ToolsButtons.tsx
+++ b/src/components/cvMaker/ToolsButtons.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { useCVSelection } from "./provider/hook";
 import useCoverLetterContext from "./CoverLetterProvider/hook";
 import { useUiStore } from "@/store/ui";
+import { getModifierKeyLabel } from "@/hooks/use-keyboard-shortcut";
 
 interface ToolsButtonsProps {
     openPicker: () => void;
@@ -33,6 +34,7 @@ export default function ToolsButtons({ openPicker, coverLetterActive = false }: 
                 className="bg-primary/70 hover:bg-green-700 text-primary-foreground/90 transition-all duration-200 transform hover:scale-105"
                 onClick={save}
                 disabled={isSaving}
+                title={`Save (${getModifierKeyLabel()}+S)`}
             >
                 <Save className="mr-2 h-4 w-4" />
                 {isSaving ? "Saving..." : "Save"}

--- a/src/components/cvMaker/provider/provider.tsx
+++ b/src/components/cvMaker/provider/provider.tsx
@@ -9,6 +9,7 @@ import { type EntityType, buildCustomKey, buildScoreKey } from '@shared/utils';
 import { type CVSelection, type CVSessionDataDTO, type JobInfos } from '@shared/jobApplications.type';
 import { toast } from 'sonner';
 import { useUiStore } from '@/store/ui';
+import { useKeyboardShortcut } from '@/hooks/use-keyboard-shortcut';
 
 export interface CVSelectionContextType {
   title: string;
@@ -479,6 +480,12 @@ export function CVSelectionProvider({ children }: { children: React.ReactNode })
       setIsSaving(false);
     }
   }, [id, title, selection, jobInfos, customTexts, scores]);
+
+  useKeyboardShortcut('s', () => {
+    if (!isSaving) {
+      void save();
+    }
+  });
 
   return (
     <CVSelectionContext.Provider value={{ 


### PR DESCRIPTION
## Description

Closes #70.

This pull request implements the requested keyboard shortcut for saving a resume in the CV Maker editor:

- **Keyboard Shortcut (`Ctrl+S` / `Cmd+S`)**: Registered `useKeyboardShortcut("s", ...)` in `CVSelectionProvider` (`src/components/cvMaker/provider/provider.tsx`) to trigger `save()` when the shortcut is invoked while editing a resume.
- **Save Guarding**: Prevents duplicate concurrent saves if a save operation is already in progress (`!isSaving`).
- **Shortcut Hint**: Added a helpful tooltip (`title`) to the Save button in `ToolsButtons.tsx` utilizing `getModifierKeyLabel()` (`Save (Ctrl+S)` on Windows/Linux, `Save (⌘+S)` on macOS) for discoverability.

## Verification

- **TypeScript check**: `npm run typecheck` (`tsc -b --noEmit`) passed with 0 errors.
- **Linter**: `npm run lint` (`eslint .`) passed with 0 warnings or errors.
- **Production build**: `npm run build` (`tsc -b && vite build`) passed cleanly, generating all client, Electron main, and preload bundles.
