### PR TITLE
feat/81-resume-tools-rewrite-button

### DIFF
--- a/src/components/cvMaker/Maker.tsx
+++ b/src/components/cvMaker/Maker.tsx
@@ -10,6 +10,7 @@ import CoverLetterTemplate from "./coverLetter/CoverLetterTemplate";
 import { Button } from "../ui/button";
 import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 import CoverLetterButtons from "./coverLetter/CoverLetterButtons";
+import ResumeTools from "./cvTemplate/ResumeTools";
 
 export default function Maker() {
     const [pickerOpen, setPickerOpen] = useState(false);
@@ -43,7 +44,7 @@ export default function Maker() {
                     </div>
                     <ToolsButtons openPicker={() => setPickerOpen(true)} coverLetterActive={coverLetterActive} />
                     {pickerOpen && <CvPicker onClose={() => setPickerOpen(false)} />}
-                    { coverLetterActive && <CoverLetterButtons />}
+                    { coverLetterActive ? <CoverLetterButtons /> : <ResumeTools />}
                 </div>
             </CoverLetterProvider>
         </CVSelectionProvider>

--- a/src/components/cvMaker/cvTemplate/ResumeTools.tsx
+++ b/src/components/cvMaker/cvTemplate/ResumeTools.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Wand2 } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+import { AIAnalysisStatus } from "@shared/AIAnalysisStatus";
+import { useCVSelection } from "../provider/hook";
+
+export default function ResumeTools() {
+    const { runAIRewrite, aiState } = useCVSelection();
+    const isRewriting = aiState.status === AIAnalysisStatus.Rewriting;
+    // a full mandate analysis is also running on the same AI, so don't start a rewrite on top of it
+    const isBusy = isRewriting || aiState.isCurrentJob;
+
+    return (
+        <TooltipProvider>
+            <div className="fixed bottom-4 right-4 flex gap-2">
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <span>
+                            <Button
+                                onClick={runAIRewrite}
+                                disabled={isBusy}
+                                aria-label="Rewrite Resume"
+                                className="group rounded-xl w-10 h-10 p-2 hover:bg-slate-100 hover:text-primary"
+                            >
+                                {isRewriting ? (
+                                    <Spinner className="h-full w-full transition-transform" />
+                                ) : (
+                                    <Wand2 className="h-full w-full transition-transform group-hover:rotate-12" />
+                                )}
+                            </Button>
+                        </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        <p>{isRewriting ? "Rewriting resume..." : "Rewrite Resume"}</p>
+                    </TooltipContent>
+                </Tooltip>
+            </div>
+        </TooltipProvider>
+    )
+}

--- a/src/components/cvMaker/provider/provider.tsx
+++ b/src/components/cvMaker/provider/provider.tsx
@@ -162,12 +162,19 @@ export function CVSelectionProvider({ children }: { children: React.ReactNode })
         scores,
       };
 
-    await api.rewriteResume({
+    const result = await api.rewriteResume({
       language: profile?.language || Language.ENGLISH,
       experiences: expsToRewrite,
       projects: projsToRewrite,
       resumeData: cvSessionData
     });
+
+    // some failures (e.g. AI unavailable) return before any status is emitted, so reset the state here
+    if (result?.error) {
+      setAiState(prev => ({ ...prev, status: AIAnalysisStatus.Error, error: result.error }));
+      setRewritingKeys([]);
+      toast.error("Failed to rewrite resume", { description: result.error });
+    }
   }, [experience, projects, id, title, selection, jobInfos, customTexts, scores, profile?.language]);
 
   const updateCustomField = useCallback((entityType: EntityType, id: string, field: string, value: string) => {
@@ -333,6 +340,12 @@ export function CVSelectionProvider({ children }: { children: React.ReactNode })
           const item = data.data as { topResumeSummary: string[] };
           setSummaryBullets(item.topResumeSummary);
           setAiState(prev => ({ ...prev, status: AIAnalysisStatus.TOP_RESUME }));
+          break;
+        }
+
+        case AIAnalysisStatus.Error: {
+          setAiState(prev => ({ ...prev, status: AIAnalysisStatus.Error, isCurrentJob: false, error: data.message }));
+          setRewritingKeys([]);
           break;
         }
 


### PR DESCRIPTION
# [Feat/AI] Add a button to easily generate the resume

Closes #81

## Problem

To start an AI resume rewrite, you had to open the Analysis panel and scroll to the bottom to click **Rewrite resume**. That's a lot of steps when you're working in the CV preview.

## What changed

### New `ResumeTools` component
`src/components/cvMaker/cvTemplate/ResumeTools.tsx`

- A wand icon button fixed to the bottom-right corner of the CV preview. Clicking it calls `runAIRewrite` from `useCVSelection`.
- It has a tooltip and uses the same styling as the Generate Cover Letter button.
- **Loading state:** while `aiState.status === AIAnalysisStatus.Rewriting`, the icon becomes a spinner and the tooltip reads "Rewriting resume...".
- **Disabled** while a rewrite is running and while a full job analysis is running (`aiState.isCurrentJob`), so two AI jobs can't run at the same time.
- The button is wrapped in a `<span>` inside `TooltipTrigger asChild`, so the tooltip still shows when the button is disabled.

### Placement
`src/components/cvMaker/Maker.tsx`

`ResumeTools` shows in the resume view and `CoverLetterButtons` shows in the cover letter view. Both buttons use the same corner, so only one is shown at a time.

### Provider fix: the loading state could get stuck
`src/components/cvMaker/provider/provider.tsx`

Before this change, the new spinner could keep spinning after a rewrite failed. There were two causes:

1. **The `Error` status wasn't handled.** `rewriteResume` sends `AIAnalysisStatus.Error` when it fails, but the provider's status listener ignored it, so the status stayed `Rewriting`. The listener now handles `Error` by setting the status to `Error` and clearing `isCurrentJob` and `rewritingKeys`.
2. **Some errors were only returned, never sent as a status.** When the AI service is unavailable, `rewriteResume` returns `{ error }` before sending any status. `runAIRewrite` now checks the returned value. On error, it resets the state and shows an error toast.

## Notes

- The button is not hidden when `aiAvailable` is false. That flag only becomes true after the user clicks the AI check in the title bar, so hiding the button would hide it most of the time. If the AI isn't running, clicking the button shows an error toast.
- The existing **Rewrite resume** button in the Analysis panel is unchanged.

## How to test

1. Start the app with Ollama running and a model downloaded.
2. Open the resume maker and select some experiences or projects (or run an analysis).
3. Click the wand button in the bottom-right corner.
   - The icon turns into a spinner and the button is disabled.
   - The selected items show their loading state and are rewritten one by one.
   - When the rewrite finishes, the button is enabled again and a success toast appears.
4. Switch to **Cover Letter**. The wand button is hidden and the cover letter button is shown.
5. Stop Ollama and click the wand again. An error toast appears and the button is enabled again.
6. Start an **Analyse with AI** from the Analysis panel. The wand button is disabled until the analysis finishes.

## Checks

- `npm run typecheck`: passes
- `eslint` on the changed files: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
