### PR TITLE
Feat/74 track job salaries

### DIFF
--- a/electron/services/jobApplications/jobApplicationDb.ts
+++ b/electron/services/jobApplications/jobApplicationDb.ts
@@ -80,5 +80,18 @@ export class JobApplicationDb {
 
         this.db.exec(applicationTable);
         this.db.exec(applicationEventsTable);
+        this.migrateSchema();
+    }
+
+    /**
+    * Adds columns introduced after the table was first created, since CREATE TABLE IF NOT EXISTS leaves existing tables untouched.
+    */
+    private migrateSchema(): void {
+        if (!this.db) return;
+
+        const columns = this.db.prepare(`PRAGMA table_info(applications)`).all() as { name: string }[];
+        if (!columns.some(column => column.name === 'salary')) {
+            this.db.exec(`ALTER TABLE applications ADD COLUMN salary INTEGER`);
+        }
     }
 }

--- a/electron/services/jobApplications/jobApplicationManager.ts
+++ b/electron/services/jobApplications/jobApplicationManager.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { Application, ApplicationEvent, ApplicationEventType, ApplicationWithEvents, CreateApplicationDto, CVSessionDataDTO, JobApplicationStatus, KeyStats } from "../../../shared/jobApplications.type";
+import { parseSalary } from "../../../shared/utils";
 import { JobApplicationDb } from "./jobApplicationDb";
 import fs from "node:fs";
 
@@ -91,10 +92,11 @@ export class JobApplicationManager {
 
         const keywords = dto.jobInfos?.keywords || [];
         const url = dto.jobInfos?.url || "";
+        const salary = parseSalary(dto.jobInfos?.salary);
 
         const stmt = rawDb.prepare(`
-            INSERT INTO applications (id, job_title, company_name, status, keywords, url, json_file_path)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO applications (id, job_title, company_name, status, keywords, salary, url, json_file_path)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         `);
 
         const eventStmt = rawDb.prepare(`
@@ -104,7 +106,7 @@ export class JobApplicationManager {
 
         try {
             const transaction = rawDb.transaction(() => {
-                stmt.run(id, jobTitle, companyName, initialStatus, keywords.join(','), url, relativeJsonPath);
+                stmt.run(id, jobTitle, companyName, initialStatus, keywords.join(','), salary, url, relativeJsonPath);
                 eventStmt.run(id, ApplicationEventType.STATUS_CHANGE, `Created with status ${initialStatus}`);
             });
             transaction();
@@ -353,14 +355,15 @@ export class JobApplicationManager {
         const companyName = sessionData.jobInfos?.company || "Unknown";
         const keywords = sessionData.jobInfos?.keywords || [];
         const url = sessionData.jobInfos?.url || "";
+        const salary = parseSalary(sessionData.jobInfos?.salary);
 
         const updateStmt = rawDb.prepare(`
-            UPDATE applications 
-            SET job_title = ?, company_name = ?, status = ?, keywords = ?, url = ?, updated_at = CURRENT_TIMESTAMP 
+            UPDATE applications
+            SET job_title = ?, company_name = ?, status = ?, keywords = ?, salary = ?, url = ?, updated_at = CURRENT_TIMESTAMP
             WHERE id = ?
         `);
 
-        updateStmt.run(jobTitle, companyName, status, keywords.join(','), url, sessionData.id);
+        updateStmt.run(jobTitle, companyName, status, keywords.join(','), salary, url, sessionData.id);
     }
 
     private getDb() {

--- a/shared/jobApplications.type.ts
+++ b/shared/jobApplications.type.ts
@@ -44,6 +44,7 @@ export interface JobInfos {
     description: string;
     focus?: string;
     keywords?: string[];
+    salary?: number | null; // yearly amount as an integer, e.g. 85000
 }
 
 export interface KeyStats {
@@ -62,6 +63,7 @@ export interface Application {
     company_name: string;            // NOT NULL
     status: JobApplicationStatus;    // CHECK (status IN (...))
     keywords: string[];
+    salary?: number | null;          // INTEGER NULLABLE
     url?: string | null;             // NULLABLE
     json_file_path?: string | null;  // NULLABLE
     pdf_file_path?: string | null;   // NULLABLE

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -7,3 +7,14 @@ export const buildCustomKey = (entityType: EntityType, id: string, field: string
 export const buildScoreKey = (entityType: EntityType, id: string): string => {
   return `${entityType}:${id}`;
 };
+
+/**
+ * Normalizes a salary (form input or IPC payload) to a non-negative integer, or null when empty/invalid.
+ */
+export const parseSalary = (value: unknown): number | null => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string' && !value.trim()) return null;
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount < 0) return null;
+  return Math.round(amount);
+};

--- a/src/components/cvMaker/NewDialog.tsx
+++ b/src/components/cvMaker/NewDialog.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { motion } from "framer-motion";
-import { Building2, FileText, Link2, Plus, Type } from "lucide-react";
+import { Building2, FileText, Link2, Plus, Type, Wallet } from "lucide-react";
+import { parseSalary } from "@shared/utils";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -56,7 +57,8 @@ export default function NewDialog({ defaultOpen = false }: Props) {
   const [company, setCompany] = useState("");
   const [url, setUrl] = useState("");
   const [description, setDescription] = useState("");
-  const [errors, setErrors] = useState<{ title?: string; company?: string }>({});
+  const [salary, setSalary] = useState("");
+  const [errors, setErrors] = useState<{ title?: string; company?: string; salary?: string }>({});
 
   const isSubmittingRef = useRef(false);
 
@@ -65,6 +67,7 @@ export default function NewDialog({ defaultOpen = false }: Props) {
     setCompany("");
     setUrl("");
     setDescription("");
+    setSalary("");
     setErrors({});
   };
 
@@ -79,8 +82,10 @@ export default function NewDialog({ defaultOpen = false }: Props) {
     const next: typeof errors = {};
     if (!title.trim()) next.title = "Job title is required";
     if (!company.trim()) next.company = "Company name is required";
+    const parsedSalary = parseSalary(salary);
+    if (salary.trim() && parsedSalary === null) next.salary = "Salary must be a positive number";
     setErrors(next);
-    if (next.title || next.company) return;
+    if (next.title || next.company || next.salary) return;
 
     isSubmittingRef.current = true;
 
@@ -89,6 +94,7 @@ export default function NewDialog({ defaultOpen = false }: Props) {
       company: company.trim(),
       url: url.trim(),
       description: description.trim(),
+      salary: parsedSalary,
     });
 
     setOpen(false);
@@ -153,16 +159,31 @@ export default function NewDialog({ defaultOpen = false }: Props) {
             </Field>
           </div>
 
-          <Field id="job-url" label="Link to job mandate" icon={Link2}>
-            <Input
-              id="job-url"
-              type="url"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              placeholder="https://company.com/careers/role"
-              className="bg-surface-elevated/60"
-            />
-          </Field>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field id="job-url" label="Link to job mandate" icon={Link2}>
+              <Input
+                id="job-url"
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://company.com/careers/role"
+                className="bg-surface-elevated/60"
+              />
+            </Field>
+            <Field id="job-salary" label="Yearly salary" icon={Wallet} error={errors.salary}>
+              <Input
+                id="job-salary"
+                type="number"
+                inputMode="numeric"
+                min={0}
+                step={1}
+                value={salary}
+                onChange={(e) => setSalary(e.target.value)}
+                placeholder="85000"
+                className="bg-surface-elevated/60"
+              />
+            </Field>
+          </div>
 
           <Field id="job-description" label="Job description / mandate" icon={FileText}>
             <Textarea

--- a/src/components/cvMaker/cvPicker/Analyse.tsx
+++ b/src/components/cvMaker/cvPicker/Analyse.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-import { Building2, Check, FileSearch, LoaderCircle, ScanSearch, Sparkles, Target, Wand2, X } from 'lucide-react';
+import { Building2, Check, FileSearch, LoaderCircle, ScanSearch, Sparkles, Target, Wallet, Wand2, X } from 'lucide-react';
+import { parseSalary } from "@shared/utils";
 import { useCVSelection } from "../provider/hook";
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -117,6 +118,22 @@ export default function Analyse() {
                                     value={jobInfos?.company || ""}
                                     onChange={(event) => updateJobInfos({ company: event.target.value })}
                                     placeholder="Company name"
+                                    className="bg-background"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="analysis-salary" className="flex items-center gap-2 text-xs">
+                                    <Wallet className="size-3.5 text-muted-foreground" /> Yearly salary
+                                </Label>
+                                <Input
+                                    id="analysis-salary"
+                                    type="number"
+                                    inputMode="numeric"
+                                    min={0}
+                                    step={1}
+                                    value={jobInfos?.salary ?? ""}
+                                    onChange={(event) => updateJobInfos({ salary: parseSalary(event.target.value) })}
+                                    placeholder="85000"
                                     className="bg-background"
                                 />
                             </div>

--- a/src/components/dashboard/JobDrawer.tsx
+++ b/src/components/dashboard/JobDrawer.tsx
@@ -102,9 +102,9 @@ export default function JobDrawer({ rawJob, onOpenChange }: Props) {
                 </div>
                 <div className="rounded-md border border-border/70 bg-surface-elevated/60 px-3 py-2">
                   <p className="flex items-center gap-1 text-muted-foreground">
-                    <Wallet className="size-3" /> Salary range
+                    <Wallet className="size-3" /> Salary
                   </p>
-                  <p className="mt-0.5 font-medium text-foreground">{job.salary || "Coming soon..."}</p>
+                  <p className="mt-0.5 font-medium text-foreground">{job.salary || "Not set"}</p>
                 </div>
               </div>
 

--- a/src/components/dashboard/mapApplicationToJabCard.ts
+++ b/src/components/dashboard/mapApplicationToJabCard.ts
@@ -33,6 +33,7 @@ export function mapApplicationToJobCard(application: Application): JobCard {
         timeline: [],
         logo: logo,
         url: application.url || undefined,
+        salary: application.salary != null ? `${application.salary.toLocaleString()} / year` : undefined,
     }
 }
 


### PR DESCRIPTION
# feat(ui+db): Allow users to track job salaries

Closes #74

## Summary

Users can now enter a yearly salary for a job application. It is stored as an `INTEGER` in the `applications` table, or `NULL` when left empty, so it can feed salary statistics later.

## Changes

### Database
- **Migration** (`electron/services/jobApplications/jobApplicationDb.ts`): the `salary` column was only added to the schema in 725759f. `CREATE TABLE IF NOT EXISTS` does not change existing tables, so databases created before that commit are missing the column. On connect, the app now checks `PRAGMA table_info(applications)` and runs `ALTER TABLE ... ADD COLUMN salary INTEGER` if the column is missing.
- **Writes** (`electron/services/jobApplications/jobApplicationManager.ts`): salary is now included in the `INSERT` (`createApplication`) and the `UPDATE` (`saveCVSession`). Both the manual save and the AI rewrite reach these through `saveOrUpdateApplication`.

### Shared
- `shared/jobApplications.type.ts`: added `salary?: number | null` to `JobInfos` (the salary is saved with the rest of the job info in the session JSON) and to `Application`.
- `shared/utils.ts`: new `parseSalary(value)` helper. It returns a non-negative rounded integer, or `null` for empty or invalid input. The UI calls it before sending over IPC, and the main process calls it again on the incoming payload.

### UI
- **Create a Resume dialog** (`src/components/cvMaker/NewDialog.tsx`): optional "Yearly salary" number field next to the job link. Invalid input shows an inline error.
- **Analyse page** (`src/components/cvMaker/cvPicker/Analyse.tsx`): the same field, so the salary can be edited after creation.
- **Job drawer** (`src/components/dashboard/JobDrawer.tsx`, `mapApplicationToJabCard.ts`): shows the stored salary (e.g. `85,000 / year`), or "Not set" in place of the old "Coming soon..." placeholder.

## Testing
- [x] `npm run typecheck` passes
- [x] `eslint` passes on the changed files
- [ ] Open the app with a database created before 725759f and confirm the `salary` column is added
- [ ] Create an application with a salary and check the value in the job drawer
- [ ] Create an application without a salary and confirm `NULL` is stored
- [ ] Edit the salary on the Analyse page, save, and confirm the update

## Notes
The same commit (725759f) also added `motivation_letter_file_path` and `notes`, which older databases are also missing. Nothing writes to them yet, so this PR only migrates `salary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
