### PR TITLE
Feat/73 sidebar profile photo

### DIFF
--- a/src/components/general/LeftMenu.tsx
+++ b/src/components/general/LeftMenu.tsx
@@ -166,9 +166,11 @@ export default function LeftMenu({ selectedTab, onSelectTab, profile, onLogout }
           <motion.div
             initial={{ scale: 0.9, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
-            className="flex size-9 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-sm font-semibold text-sidebar-primary-foreground"
+            className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-md bg-sidebar-primary text-sm font-semibold text-sidebar-primary-foreground"
           >
-            {initials}
+            {profile?.photo
+              ? <img src={profile.photo} alt={`${firstName} ${lastName}`} className="size-full object-cover" />
+              : initials}
           </motion.div>
           <div className="min-w-0 flex-1 group-data-[collapsible=icon]:hidden">
             <p className="truncate text-sm font-semibold text-sidebar-foreground">


### PR DESCRIPTION
## Summary
Closes #73

The avatar at the top of the left menu now shows the user's profile picture when one exists. Users without a photo still see their initials.

## Changes
- `src/components/general/LeftMenu.tsx`: the avatar shows `profile.photo` when it is set and falls back to the initials otherwise.
  - The image fills the existing `size-9` rounded box (`object-cover`), and `overflow-hidden` clips it to the rounded corners.
  - Alt text is the user's full name.

## Notes
- The photo comes from the profile store, so saving or removing it on the Personal information page updates the menu right away.
- The per-resume "hide photo" option only affects the CV. The menu shows the photo whenever the profile has one.
- Layout is unchanged in both the expanded and collapsed sidebar.

## Test plan
- [x] `npm run typecheck` passes
- [x] `eslint` passes on `LeftMenu.tsx`
- [ ] Profile with a photo: the photo shows in the sidebar, expanded and collapsed
- [ ] Profile without a photo: the initials show as before
- [ ] Upload, replace and remove a photo, then save: the sidebar updates without a reload

